### PR TITLE
feat(docs): implement GitHub Pages and automated documentation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,87 @@
+name: Deploy GitHub Pages
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Corre diariamente
+  workflow_dispatch:      # Permite ejecutar manualmente
+  push:
+    branches: [ "main" ]  # Solo en la rama principal
+  issues:
+    types: [opened, closed, edited, deleted]
+  milestone:
+    types: [created, closed, edited, deleted]
+
+# Corregimos la sintaxis de los permisos
+permissions:
+  contents: write    # Para repo y wiki
+  pages: write      # Para GitHub Pages
+  id-token: write   # Para autenticación
+  issues: read          # Para leer issues
+  pull-requests: write  # Para PR y merge
+  repository-projects: write
+  actions: read         # Para acceder a las acciones
+  deployments: write    # Para despliegues
+  statuses: write       # Para actualizar estados
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install PyGithub markdown2 jinja2 requests
+
+      - name: Fetch Issues and Milestones
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/fetch_github_data.py
+
+      - name: Generate Documentation
+        run: |
+          python scripts/generate_docs.py
+
+      - name: Generate Wiki
+        env:
+          GITHUB_TOKEN: ${{ secrets.WIKI_TOKEN }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          python scripts/generate_wiki.py
+      
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+        
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+      
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./_site
+      
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,20 @@
+title: SAUCE Agua Core Service
+description: Documentación del servicio Core de SAUCE Agua
+theme: jekyll-theme-cayman
+
+# Configuración importante para Jekyll
+defaults:
+  -
+    scope:
+      path: "" # aplica a todos los archivos
+    values:
+      layout: default
+
+# Especificar que los archivos .md deben ser procesados
+markdown: kramdown
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
+
+# Configurar la página principal
+index_page: index.md 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,22 @@
+---
+layout: default
+---
+
+# SAUCE Agua Core Service
+
+Bienvenido a la documentación del servicio Core de SAUCE Agua.
+
+## Descripción
+
+Este es el servidor de core para la arquitectura de microservicios de SAUCE Agua.
+
+## Navegación
+
+- [Documentación Detallada del Proyecto](project-documentation.html) - Documentación generada automáticamente con:
+  - Estado actual de los Milestones
+  - Lista de Issues activos y cerrados
+  - Historial de cambios
+
+## Estado del Proyecto
+
+El estado actual del proyecto y sus avances se pueden consultar en la [Documentación Detallada](project-documentation.html).

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.3</version>
+            <version>2.8.4</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>

--- a/scripts/fetch_github_data.py
+++ b/scripts/fetch_github_data.py
@@ -1,0 +1,46 @@
+from github import Github
+import json
+import os
+
+def fetch_github_data():
+    # Inicializar cliente de GitHub
+    g = Github(os.environ['GITHUB_TOKEN'])
+    
+    # Obtener el repositorio actual
+    repo = g.get_repo(os.environ['GITHUB_REPOSITORY'])
+    
+    # Obtener issues
+    issues_data = []
+    for issue in repo.get_issues(state='all'):
+        issues_data.append({
+            'number': issue.number,
+            'title': issue.title,
+            'state': issue.state,
+            'created_at': issue.created_at.isoformat(),
+            'closed_at': issue.closed_at.isoformat() if issue.closed_at else None,
+            'labels': [label.name for label in issue.labels],
+            'milestone': issue.milestone.title if issue.milestone else None,
+            'body': issue.body or ''
+        })
+    
+    # Obtener milestones
+    milestones_data = []
+    for milestone in repo.get_milestones(state='all'):
+        milestone_data = {
+            'title': milestone.title,
+            'description': milestone.description or '',
+            'state': milestone.state,
+            'created_at': milestone.created_at.isoformat() if milestone.created_at else None,
+            'due_on': milestone.due_on.isoformat() if milestone.due_on else None
+        }
+        milestones_data.append(milestone_data)
+    
+    # Guardar datos
+    os.makedirs('data', exist_ok=True)
+    with open('data/issues.json', 'w') as f:
+        json.dump(issues_data, f, indent=2)
+    with open('data/milestones.json', 'w') as f:
+        json.dump(milestones_data, f, indent=2)
+
+if __name__ == '__main__':
+    fetch_github_data() 

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -1,0 +1,87 @@
+import json
+from datetime import datetime
+from jinja2 import Template
+import os
+
+def load_data():
+    with open('data/issues.json', 'r') as f:
+        issues = json.load(f)
+    with open('data/milestones.json', 'r') as f:
+        milestones = json.load(f)
+    return issues, milestones
+
+def generate_docs():
+    issues, milestones = load_data()
+    
+    # Template para la documentación
+    template_str = """---
+layout: default
+title: Documentación Detallada
+---
+
+# Documentación Detallada del Proyecto
+
+_Última actualización: {{ current_date }}_
+
+## Resumen de Milestones
+
+| Milestone | Estado | Fecha Límite |
+|-----------|--------|--------------|
+{% for milestone in milestones %}
+| {{ milestone.title }} | {{ milestone.state }} | {{ milestone.due_on if milestone.due_on else 'No definida' }} |
+{% endfor %}
+
+## Detalles de Milestones
+
+{% for milestone in milestones %}
+### {{ milestone.title }}
+**Estado:** {{ milestone.state }}
+**Descripción:** {{ milestone.description }}
+{% if milestone.due_on %}**Fecha límite:** {{ milestone.due_on }}{% endif %}
+
+---
+{% endfor %}
+
+## Issues Activos
+
+{% for issue in issues if issue.state == 'open' %}
+### #{{ issue.number }}: {{ issue.title }}
+**Estado:** {{ issue.state }}
+**Creado:** {{ issue.created_at }}
+{% if issue.milestone %}**Milestone:** {{ issue.milestone }}{% endif %}
+{% if issue.labels %}**Labels:** {{ issue.labels|join(', ') }}{% endif %}
+
+{{ issue.body }}
+
+---
+{% endfor %}
+
+## Issues Cerrados
+
+{% for issue in issues if issue.state == 'closed' %}
+### #{{ issue.number }}: {{ issue.title }}
+**Estado:** {{ issue.state }}
+**Creado:** {{ issue.created_at }}
+**Cerrado:** {{ issue.closed_at }}
+{% if issue.milestone %}**Milestone:** {{ issue.milestone }}{% endif %}
+{% if issue.labels %}**Labels:** {{ issue.labels|join(', ') }}{% endif %}
+
+{{ issue.body }}
+
+---
+{% endfor %}
+"""
+    
+    template = Template(template_str)
+    doc_content = template.render(
+        current_date=datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+        issues=issues,
+        milestones=milestones
+    )
+    
+    # Guardar la documentación
+    with open('docs/project-documentation.md', 'w') as f:
+        f.write(doc_content)
+
+if __name__ == '__main__':
+    generate_docs() 

--- a/scripts/generate_wiki.py
+++ b/scripts/generate_wiki.py
@@ -1,0 +1,350 @@
+import os
+import json
+import subprocess
+from pathlib import Path
+import requests
+
+class WikiGenerationError(Exception):
+    """Error específico para generación de wiki"""
+    pass
+
+def run_command(cmd, check=True):
+    """Ejecutar comando con mejor manejo de errores"""
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if check and result.returncode != 0:
+        print(f"Error ejecutando {' '.join(cmd)}")
+        print(f"stdout: {result.stdout}")
+        print(f"stderr: {result.stderr}")
+        raise subprocess.CalledProcessError(result.returncode, cmd)
+    return result
+
+def get_default_branch(wiki_url, headers):
+    """Determinar la rama por defecto de la wiki"""
+    try:
+        result = run_command(['git', 'ls-remote', '--symref', wiki_url, 'HEAD'], check=False)
+        if 'ref: refs/heads/master' in result.stdout:
+            return 'master'
+    except:
+        pass
+    return 'main'  # Default a main si no podemos determinar
+
+def run_git_command(cmd, error_msg=None, check=True):
+    """Ejecutar comando git con mejor manejo de errores"""
+    try:
+        result = run_command(cmd, check=False)  # Siempre False para manejar errores nosotros
+        if check and result.returncode != 0:  # Solo verificar si check=True
+            if 'Authentication failed' in result.stderr:
+                raise WikiGenerationError("Autenticación Git fallida. Verifica el token.")
+            elif 'repository not found' in result.stderr:
+                raise WikiGenerationError("Repositorio wiki no encontrado. Verifica que esté habilitado.")
+            elif error_msg:
+                raise WikiGenerationError(f"{error_msg}: {result.stderr}")
+            else:
+                raise WikiGenerationError(f"Error en comando Git: {result.stderr}")
+        return result
+    except Exception as e:
+        if not isinstance(e, WikiGenerationError):
+            raise WikiGenerationError(f"Error ejecutando Git: {str(e)}")
+        raise
+
+def verify_token():
+    """Verificar que el token existe y tiene el formato correcto"""
+    token = os.environ.get('GITHUB_TOKEN')
+    if not token:
+        raise WikiGenerationError("GITHUB_TOKEN no encontrado en variables de entorno")
+    if not token.strip():
+        raise WikiGenerationError("GITHUB_TOKEN está vacío")
+    return token
+
+def generate_wiki_pages():
+    # Guardar directorio original y asegurar paths absolutos
+    original_dir = Path.cwd().absolute()
+    data_dir = original_dir / 'data'
+    wiki_dir = original_dir / 'wiki_content'
+    
+    print(f"Iniciando generación de Wiki desde {original_dir}")
+    
+    # Inicializar flag de éxito
+    success = False
+    
+    # Verificar directorio de datos
+    if not data_dir.exists():
+        raise WikiGenerationError(f"Directorio de datos no encontrado: {data_dir}")
+    
+    try:
+        token = verify_token()
+        # Limpiar directorio wiki si existe
+        if wiki_dir.exists():
+            safe_cleanup(wiki_dir)
+        
+        # Configuración
+        repo = os.environ['GITHUB_REPOSITORY']
+        api_url = f"https://api.github.com/repos/{repo}"
+        headers = {
+            'Authorization': f'Bearer {token}',
+            'Accept': 'application/vnd.github.v3+json,application/vnd.github.mercy-preview+json',
+            'X-GitHub-Api-Version': '2022-11-28'  # Especificar versión de API
+        }
+
+        # Verificar acceso y permisos en una sola llamada
+        print("Verificando acceso al repositorio y permisos...")
+        repo_data = check_repo_access(api_url, headers)
+        
+        # Habilitar wiki si es necesario
+        if not repo_data.get('has_wiki'):
+            print("Habilitando wiki...")
+            response = requests.patch(api_url, headers=headers, json={'has_wiki': True})
+            if response.status_code != 200:
+                raise WikiGenerationError(f"Error habilitando wiki: {response.status_code}")
+
+        # URL para git con autenticación (formato más seguro)
+        wiki_url = f"https://x-access-token:{token}@github.com/{repo}.wiki.git"
+        print("URL de wiki configurada (token oculto)")
+        
+        # Configurar git
+        run_command(['git', 'config', '--global', 'user.name', 'github-actions[bot]'])
+        run_command(['git', 'config', '--global', 'user.email', 'github-actions[bot]@users.noreply.github.com'])
+        
+        # Verificar acceso Git
+        print("Verificando acceso Git...")
+        run_git_command(['git', 'ls-remote', wiki_url], 
+                       "No se puede acceder al repositorio wiki")
+        
+        # Intentar clonar
+        print(f"Intentando clonar wiki en: {wiki_dir}")
+        clone_result = run_git_command(['git', 'clone', wiki_url, str(wiki_dir)],
+                                     "Error clonando repositorio wiki",
+                                     check=False)  # No verificar aquí
+        
+        is_new_wiki = clone_result.returncode != 0
+        
+        if is_new_wiki:
+            # Inicializar nuevo repositorio
+            wiki_dir.mkdir(exist_ok=True)
+            os.chdir(str(wiki_dir))
+            run_git_command(['git', 'init'],
+                          "Error inicializando repositorio")
+            run_git_command(['git', 'remote', 'add', 'origin', wiki_url],
+                          "Error configurando remote")
+            
+            # Generar y commit contenido inicial
+            if not generate_wiki_content(wiki_dir, data_dir):
+                raise WikiGenerationError("No se pudo generar el contenido inicial")
+            
+            run_git_command(['git', 'add', '.'])
+            run_git_command(['git', 'commit', '-m', 'Initial wiki content'])
+            run_git_command(['git', 'branch', '-M', 'main'])
+            run_git_command(['git', 'push', '--force', 'origin', 'main'])
+            print("Wiki inicializada exitosamente")
+        else:
+            # Wiki existente
+            os.chdir(str(wiki_dir))
+            default_branch = get_default_branch(wiki_url, headers)
+            print(f"Usando rama existente: {default_branch}")
+            
+            # Verificar checkout y pull
+            checkout_result = run_git_command(['git', 'checkout', default_branch], 
+                                            "Error cambiando a rama por defecto")  # Siempre verificar
+            
+            pull_result = run_git_command(['git', 'pull', 'origin', default_branch],
+                                        "Error actualizando rama")  # Siempre verificar
+            
+            if not generate_wiki_content(wiki_dir, data_dir):
+                raise WikiGenerationError("No se pudo generar el contenido")
+            
+            # Verificar y commit cambios
+            run_git_command(['git', 'add', '.'])
+            status = run_git_command(['git', 'status', '--porcelain'])
+            if status.stdout.strip():
+                run_git_command(['git', 'commit', '-m', 'Update wiki content'])
+                run_git_command(['git', 'push', 'origin', default_branch])
+                print("Wiki actualizada exitosamente")
+        success = True  # Si llegamos aquí, todo salió bien
+        
+    except WikiGenerationError:
+        # Re-lanzar errores específicos de wiki
+        raise
+    except subprocess.CalledProcessError as e:
+        if 'Authentication failed' in str(e):
+            raise WikiGenerationError("Autenticación Git fallida. Verifica el token.")
+        raise WikiGenerationError(f"Error en operación Git: {str(e)}")
+    except requests.RequestException as e:
+        raise WikiGenerationError(f"Error en API de GitHub: {str(e)}")
+    except Exception as e:
+        raise WikiGenerationError(f"Error inesperado: {str(e)}")
+    finally:
+        # Volver al directorio original
+        os.chdir(str(original_dir))
+        print(f"Volviendo a directorio original: {original_dir}")
+        
+        # Limpiar si no hubo éxito
+        if not success and wiki_dir.exists():
+            safe_cleanup(wiki_dir)
+        
+        # Limpiar credenciales
+        if os.path.exists(os.path.expanduser('~/.git-credentials')):
+            os.remove(os.path.expanduser('~/.git-credentials'))
+
+def generate_wiki_content(wiki_dir: Path, data_dir: Path):
+    """Generar contenido de la wiki usando Path consistentemente"""
+    # Verificar y cargar archivos JSON
+    issues_file = data_dir / 'issues.json'
+    milestones_file = data_dir / 'milestones.json'
+    
+    # Verificar contenido antes de procesar
+    issues = verify_json_content(issues_file)
+    milestones = verify_json_content(milestones_file)
+    
+    if not issues and not milestones:
+        print("No hay datos para generar en la wiki")
+        return False
+
+    # Generar archivos usando Path consistentemente
+    try:
+        # Home.md
+        with open(wiki_dir / 'Home.md', 'w', encoding='utf-8') as f:
+            f.write("""# SAUCE Agua Eureka Service Wiki
+
+Bienvenido a la Wiki del servicio Eureka de SAUCE Agua.
+
+## Navegación Rápida
+
+- [[Milestones]]
+- [[Issues-Activos]]
+- [[Issues-Cerrados]]
+""")
+
+        # Milestones.md
+        with open(wiki_dir / 'Milestones.md', 'w', encoding='utf-8') as f:
+            f.write("# Milestones\n\n")
+            for ms in milestones:
+                f.write(f"## {ms['title']}\n")
+                f.write(f"**Estado:** {ms['state']}\n\n")
+                description = ms.get('description') or 'Sin descripción'
+                f.write(f"**Descripción:** {description}\n\n")
+                if ms.get('due_on'):
+                    f.write(f"**Fecha límite:** {ms['due_on']}\n\n")
+                f.write("---\n\n")
+
+        # Issues-Activos.md
+        def format_labels(labels_data):
+            """Formatear labels considerando diferentes formatos posibles"""
+            if not labels_data:
+                return []
+            if isinstance(labels_data, list):
+                # Si es una lista de diccionarios
+                if all(isinstance(label, dict) for label in labels_data):
+                    return [label.get('name', '') for label in labels_data]
+                # Si es una lista de strings
+                return labels_data
+            # Si es un string único
+            if isinstance(labels_data, str):
+                return [labels_data]
+            return []
+
+        active_issues = [i for i in issues if i['state'] == 'open']
+        with open(wiki_dir / 'Issues-Activos.md', 'w', encoding='utf-8') as f:
+            f.write("# Issues Activos\n\n")
+            for issue in active_issues:
+                f.write(f"## #{issue['number']}: {issue['title']}\n")
+                f.write(f"**Creado:** {issue['created_at']}\n\n")
+                if issue.get('milestone'):
+                    # Si milestone es un diccionario
+                    if isinstance(issue['milestone'], dict):
+                        milestone_title = issue['milestone'].get('title', 'Sin título')
+                    # Si milestone es un string
+                    else:
+                        milestone_title = issue['milestone']
+                    f.write(f"**Milestone:** {milestone_title}\n\n")
+                if issue.get('labels'):
+                    labels = format_labels(issue['labels'])
+                    if labels:
+                        f.write(f"**Labels:** {', '.join(labels)}\n\n")
+                body = issue.get('body') or 'Sin descripción'
+                f.write(f"{body}\n\n---\n\n")
+
+        # Issues-Cerrados.md
+        closed_issues = [i for i in issues if i['state'] == 'closed']
+        with open(wiki_dir / 'Issues-Cerrados.md', 'w', encoding='utf-8') as f:
+            f.write("# Issues Cerrados\n\n")
+            for issue in closed_issues:
+                f.write(f"## #{issue['number']}: {issue['title']}\n")
+                f.write(f"**Creado:** {issue['created_at']}\n")
+                f.write(f"**Cerrado:** {issue.get('closed_at', 'Desconocido')}\n\n")
+                if issue.get('milestone'):
+                    # Si milestone es un diccionario
+                    if isinstance(issue['milestone'], dict):
+                        milestone_title = issue['milestone'].get('title', 'Sin título')
+                    # Si milestone es un string
+                    else:
+                        milestone_title = issue['milestone']
+                    f.write(f"**Milestone:** {milestone_title}\n\n")
+                if issue.get('labels'):
+                    labels = format_labels(issue['labels'])
+                    if labels:
+                        f.write(f"**Labels:** {', '.join(labels)}\n\n")
+                body = issue.get('body') or 'Sin descripción'
+                f.write(f"{body}\n\n---\n\n")
+
+        return True
+    except IOError as e:
+        print(f"Error escribiendo archivos de la wiki: {e}")
+        return False
+
+def verify_json_content(file_path):
+    """Verificar que el archivo JSON tiene contenido válido"""
+    if not os.path.exists(file_path):
+        raise WikiGenerationError(f"Archivo no encontrado: {file_path}")
+        
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+            if not data:
+                print(f"Advertencia: {file_path} está vacío")
+            return data
+    except json.JSONDecodeError as e:
+        raise WikiGenerationError(f"Error decodificando {file_path}: {e}")
+    except IOError as e:
+        raise WikiGenerationError(f"Error leyendo archivo {file_path}: {e}")
+
+def safe_cleanup(directory):
+    """Limpieza segura de directorio temporal"""
+    if os.path.exists(directory) and os.path.isdir(directory):
+        try:
+            subprocess.run(['rm', '-rf', directory], check=True)
+        except subprocess.CalledProcessError as e:
+            print(f"Error limpiando {directory}: {e}")
+
+def check_repo_access(api_url, headers):
+    """Verificar acceso al repositorio y sus características"""
+    try:
+        response = requests.get(api_url, headers=headers)
+        response.raise_for_status()  # Lanzar excepción para códigos de error HTTP
+        
+        repo_data = response.json()
+        
+        # Verificar permisos específicos para wiki
+        permissions = repo_data.get('permissions', {})
+        
+        # Verificar todos los permisos necesarios
+        if not permissions.get('push'):
+            print("Permisos actuales:", permissions)  # Debug
+            raise WikiGenerationError("El token no tiene permisos de escritura")
+        if not permissions.get('pull'):
+            raise WikiGenerationError("El token no tiene permisos de lectura")
+        if not repo_data.get('has_wiki') and not permissions.get('admin'):
+            raise WikiGenerationError("La wiki está deshabilitada y el token no tiene permisos para habilitarla")
+        
+        return repo_data
+    except requests.exceptions.RequestException as e:
+        if response.status_code == 401:
+            raise WikiGenerationError("Token inválido o expirado")
+        elif response.status_code == 403:
+            raise WikiGenerationError("Token sin permisos suficientes")
+        elif response.status_code == 404:
+            raise WikiGenerationError("Repositorio no encontrado")
+        else:
+            raise WikiGenerationError(f"Error de API: {str(e)}")
+
+if __name__ == '__main__':
+    generate_wiki_pages() 

--- a/src/main/java/sauce/agua/rest/controller/facade/ConsumoController.java
+++ b/src/main/java/sauce/agua/rest/controller/facade/ConsumoController.java
@@ -1,16 +1,11 @@
 package sauce.agua.rest.controller.facade;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import sauce.agua.rest.model.internal.ConsumoContextDto;
 import sauce.agua.rest.model.internal.DatoConsumo;
 import sauce.agua.rest.service.facade.ConsumoService;
-
-import java.time.OffsetDateTime;
 
 @RestController
 @RequestMapping({"/consumo", "/api/core/consumo"})
@@ -23,10 +18,10 @@ public class ConsumoController {
         this.service = service;
     }
 
-    @GetMapping("/calculate/{clienteId}/{periodoId}/{medidorId}/{fechaEmision}")
-    public ResponseEntity<DatoConsumo> calculateConsumo(@PathVariable Long clienteId, @PathVariable Integer periodoId, @PathVariable String medidorId, @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime fechaEmision) {
-        log.debug("Processing controller calculateConsumo clienteId={}, periodoId={}, medidorId={}, fechaEmision={}", clienteId, periodoId, medidorId, fechaEmision);
-        return ResponseEntity.ok(service.calculateConsumo(clienteId, periodoId, medidorId, fechaEmision));
+    @PostMapping("/calculate")
+    public ResponseEntity<DatoConsumo> calculateConsumo(@RequestBody ConsumoContextDto consumoContext) {
+        log.debug("Processing controller calculateConsumo clienteId={}, periodoId={}, medidorId={}, fechaEmision={}", consumoContext.getClienteId(), consumoContext.getPeriodoId(), consumoContext.getMedidorId(), consumoContext.getFechaEmision());
+        return ResponseEntity.ok(service.calculateConsumo(consumoContext.getClienteId(), consumoContext.getPeriodoId(), consumoContext.getMedidorId(), consumoContext.getFechaEmision()));
     }
 
 }

--- a/src/main/java/sauce/agua/rest/model/internal/ConsumoContextDto.java
+++ b/src/main/java/sauce/agua/rest/model/internal/ConsumoContextDto.java
@@ -1,0 +1,20 @@
+package sauce.agua.rest.model.internal;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.OffsetDateTime;
+
+@Data
+@Builder
+public class ConsumoContextDto {
+
+    private Long clienteId;
+    private Integer periodoId;
+    private String medidorId;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    private OffsetDateTime fechaEmision;
+
+}


### PR DESCRIPTION
This commit adds comprehensive documentation automation including GitHub Pages setup and wiki generation.

BREAKING CHANGES:
- ConsumoController now uses POST with RequestBody instead of GET with path variables

Features:
- Added GitHub Actions workflow for Pages deployment
- Implemented Jekyll configuration with Cayman theme
- Created Python scripts for documentation automation:
  * fetch_github_data.py for API interaction
  * generate_docs.py for markdown generation
  * generate_wiki.py for wiki updates
- Added ConsumoContextDto for better request handling

Configuration:
- Set up GitHub Pages with Jekyll
- Configured daily automated updates
- Added proper permissions for GitHub Actions
- Updated springdoc-openapi to version 2.8.4

Documentation:
- Created initial docs structure
- Added index page and configuration
- Implemented automated wiki generation
- Added proper error handling and logging

Security:
- Implemented proper token handling
- Added secure git operations
- Configured appropriate GitHub permissions

Testing:
- Verified documentation generation
- Tested wiki updates
- Validated GitHub Actions workflow

Closes #20