### PR TITLE
fix(consumo): add constructors to ConsumoContextDto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-03-31
+
+### Added
+- feat: Agregados constructores AllArgsConstructor y NoArgsConstructor en ConsumoContextDto para mejora de serialización JSON
+
 ## [1.0.0] - 2026-03-30
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ar.com</groupId>
     <artifactId>sauce.agua.rest</artifactId>
-    <version>0.1.1</version>
+    <version>1.0.1</version>
     <name>SAUCE.agua.core-service</name>
     <description>Demo project for Spring Boot</description>
 

--- a/src/main/java/sauce/agua/rest/model/internal/ConsumoContextDto.java
+++ b/src/main/java/sauce/agua/rest/model/internal/ConsumoContextDto.java
@@ -1,13 +1,17 @@
 package sauce.agua.rest.model.internal;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.OffsetDateTime;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ConsumoContextDto {
 
     private Long clienteId;


### PR DESCRIPTION
Closes #37

## Descripción
Agregado de constructores (AllArgsConstructor y NoArgsConstructor) a la clase ConsumoContextDto para mejorar la serialización JSON.

## Cambios Realizados
- Agregado AllArgsConstructor y NoArgsConstructor a ConsumoContextDto
- Actualización de CHANGELOG.md
- Incremento de versión en pom.xml

## Verificación
Verificar que la serialización JSON funcione correctamente con los nuevos constructores.