### PR TITLE
chore(release): v1.0.2 - Spring Boot 4.0.6 upgrade, mail removal, and docs updates

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -22,10 +22,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 24
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 
@@ -116,28 +116,26 @@ jobs:
                   `;
                   document.getElementById('stats').innerHTML = statsHTML;
 
-                  // --- Architecture Diagram ---
-                  const architectureHTML = `
-                      <h2>🏛️ Arquitectura del Servicio</h2>
-                      <div class="mermaid">
-                          graph TD
-                              subgraph "Internet"
-                                  Client[Cliente Externo]
-                              end
+                   // --- Architecture Diagram ---
+                   const architectureHTML = `
+                       <h2>🏛️ Arquitectura del Servicio</h2>
+                       <div class="mermaid">
+                           graph TD
+                               subgraph "Internet"
+                                   Client[Cliente Externo]
+                               end
 
-                              subgraph "SAUCE Ecosystem"
-                                  AguaService[SAUCE Agua Core Service]
-                                  DB[(Base de Datos MySQL)]
-                                  Consul[Consul Discovery]
-                                  Mail[Servicio de Correo]
-                              end
+                               subgraph "SAUCE Ecosystem"
+                                   AguaService[SAUCE Agua Core Service]
+                                   DB[(Base de Datos MySQL)]
+                                   Consul[Consul Discovery]
+                               end
 
-                              Client -- HTTPS --> AguaService
-                              AguaService -- CRUD --> DB
-                              AguaService -- Registra Servicios --> Consul
-                              AguaService -- Envía Notificaciones --> Mail
-                      </div>
-                  `;
+                               Client -- HTTPS --> AguaService
+                               AguaService -- CRUD --> DB
+                               AguaService -- Registra Servicios --> Consul
+                       </div>
+                   `;
                   document.getElementById('architecture').innerHTML = architectureHTML;
 
                   // --- Sequence Diagram ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-04-28
+
+### Changed
+- Upgrade Spring Boot: 4.0.4 → 4.0.6 (pom.xml parent)
+- Remove spring-boot-starter-mail dependency and mail configuration (bootstrap.yml)
+
+### Removed
+- Mail service configuration and health check from bootstrap.yml
+
 ## [1.0.1] - 2026-03-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![SAUCE.agua.rest CI](https://github.com/SAUCE-services/SAUCE.agua.core-service/actions/workflows/maven.yml/badge.svg)](https://github.com/SAUCE-services/SAUCE.agua.core-service/actions/workflows/maven.yml)
 [![Java](https://img.shields.io/badge/Java-25-orange.svg)](https://www.oracle.com/java/)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.4-brightgreen.svg)](https://spring.io/projects/spring-boot)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.6-brightgreen.svg)](https://spring.io/projects/spring-boot)
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-blue.svg)](https://spring.io/projects/spring-cloud)
 [![Maven](https://img.shields.io/badge/Maven-3.8.8-red.svg)](https://maven.apache.org/)
 [![MySQL](https://img.shields.io/badge/MySQL-8.0-blue.svg)](https://www.mysql.com/)
@@ -12,7 +12,7 @@ Servicio core para la gestión de servicios de agua, parte del ecosistema SAUCE.
 ## Tecnologías Principales
 
 - Java 25
-- Spring Boot 4.0.4
+- Spring Boot 4.0.6
 - Spring Cloud 2025.1.0
 - Spring Data JPA
 - MySQL

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.6</version>
         <relativePath/>
         <!-- lookup parent from repository -->
     </parent>
     <groupId>ar.com</groupId>
     <artifactId>sauce.agua.rest</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <name>SAUCE.agua.core-service</name>
     <description>Demo project for Spring Boot</description>
 
@@ -44,10 +44,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -9,9 +9,6 @@ app:
   database: agua
   user: root
   password: root
-  mail:
-    username: uid
-    password: pwd
 
 server:
   port: ${app.port}
@@ -36,26 +33,6 @@ spring:
     hibernate:
       ddl-auto: none
     open-in-view: false
-  mail:
-    host: smtp.gmail.com
-    port: 587
-    username: ${app.mail.username}
-    password: ${app.mail.password}
-    properties:
-      mail:
-        smtp:
-          starttls:
-            enable: true
-            required: true
-          auth: true
-          connectiontimeout: 5000
-          timeout: 5000
-          writetimeout: 5000
-
-management:
-  health:
-    mail:
-      enabled: false
 
 logging:
   level:


### PR DESCRIPTION
Closes #39

## Descripción
Este PR implementa los cambios para el lanzamiento de la versión **1.0.2** del servicio SAUCE.agua.core-service, incluyendo actualización de Spring Boot, eliminación del servicio de correo y actualizaciones de documentación.

## Cambios Realizados
- **Dependencias**: Upgrade Spring Boot 4.0.4 → 4.0.6, versión del proyecto 1.0.1 → 1.0.2
- **Eliminación de Mail**: Removido `spring-boot-starter-mail` y configuración completa de `bootstrap.yml` (credenciales, SMTP, health check)
- **Documentación**: Actualizados README badges y CHANGELOG.md con entrada para v1.0.2
- **CI/CD**: Actualizado JDK 24 → 25 en `generate-docs.yml`, eliminada referencia a servicio de correo en diagrama Mermaid

## Verificación
- Build exitoso con `./mvnw clean verify`
- Pipeline de CI (maven.yml) pasa correctamente
- Documentación generada correctamente en Pages
